### PR TITLE
move test into src and update build configs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,10 +4,8 @@ module.exports = {
       tsConfig: 'tsconfig.json',
     },
   },
-  moduleFileExtensions: ['ts', 'js'],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  testMatch: ['**/test/**/*.test.(ts|js)'],
   testEnvironment: 'node',
 };

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint --ext .js --ext .ts ./src ./test",
-    "test": "jest --forceExit --coverage --verbose",
+    "lint": "eslint --ext .js --ext .ts ./src",
+    "test": "jest --forceExit --coverage --verbose ./src",
     "build": "tsc",
     "watch": "tsc -w"
   },

--- a/src/hello.spec.ts
+++ b/src/hello.spec.ts
@@ -1,4 +1,4 @@
-const { greetings } = require('../dist/hello');
+const { greetings } = require('./hello');
 
 describe('hello', () => {
   describe('greetings', () => {

--- a/src/hi.spec.js
+++ b/src/hi.spec.js
@@ -1,4 +1,4 @@
-const { greetings } = require('../dist/hi');
+const { greetings } = require('./hi');
 
 describe('hi', () => {
   describe('greetings', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,8 @@
     "noImplicitAny": false,
     "moduleResolution": "node",
     "sourceMap": true,
-    "outDir": "dist",
-    "baseUrl": ".",
-    "paths": {
-      "*": ["node_modules/*", "src/types/*"]
-    }
+    "outDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.spec.ts", "**/*.spec.js"]
 }


### PR DESCRIPTION
## AS-IS

- keep separated js/ts source from thier test cases
- test cases has extension `.test.js`, `.test.ts`, ...

```
src/
  hi.js
  hello.ts
test/
  hi.test.js
  hello.test.ts
```

## TO-BE

- both js/ts source and test cases are located in `src/` **side-by-side**
- test cases has extension `.spec.js`, `.spec.js`, ...

```
src/
  hi.js
  hi.spec.js
  hello.ts
  hello.spec.ts
```